### PR TITLE
Restructure and enhance Inference and Computation Choices section

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -61,7 +61,7 @@
 \newpage
 \begin{abstract}
 %Lead: Sam Abbott
-Infectious disease modelling increasingly relies on integrating multiple data sources. Recent outbreaks have demonstrated how rapidly evolving data landscapes create both opportunities and challenges for modellers seeking to integrate diverse data streams. These settings are characterised by evolving research questions, emerging data sources, and adapting surveillance systems that require flexible analytical approaches. The infectious disease modelling community has been slow to adopt rigorous Bayesian workflow approaches for integrating diverse data streams, which might help mitigate these domain-specific challenges, even as these methods become increasingly formalised and widely used in other domains. This paper presents a methodological framework for integrating multiple data sources in infectious disease modelling that serves both as guidance for practitioners and as a checklist for readers evaluating modelling papers, building on non-domain-specific Bayesian workflow advice. We first outline an approach for characterising epidemiological data source properties through a structured checklist, then present an iterative workflow that extends established Bayesian model development approaches to the infectious disease domain, with the checklist informing decisions throughout each workflow stage. Our workflow includes defining the research question, development of directed acyclic graph (DAG) representations of process and observation models, integration method selection, with explicit consideration of data conflicts and uncertainty quantification, model fitting choices, and real-world considerations. Throughout, we identify feedback loops where later decisions impact earlier choices. We provide an overview of approaches for each step as well as practical guidelines for integration choices, validation strategies, and conflict resolution between data sources. In addition to outlining this workflow, we also provide guidance on using it in evolving settings, such as outbreaks, and on good reporting practices. To demonstrate this workflow, we use schematic case studies of estimating transmission intensity and give examples of how practitioners can navigate real-world trade-offs between model complexity, computational feasibility, and inferential goals. The case studies show how different data types, including individual-level observations, can provide complementary information but may also impact other workflow choices. Our suggested framework emphasises parsimony, interpretability, and model criticism. By establishing systematic workflow practices that bridge methodological rigour and practical implementation, this framework offers a foundation for improving both the quality and transparency of infectious disease modelling, particularly during rapidly evolving outbreaks where flexible, principled approaches are essential. 
+Infectious disease modelling increasingly relies on integrating multiple data sources. Recent outbreaks have demonstrated how rapidly evolving data landscapes create both opportunities and challenges for modellers seeking to integrate diverse data streams. These settings are characterised by evolving research questions, emerging data sources, and adapting surveillance systems that require flexible analytical approaches. The infectious disease modelling community has been slow to adopt rigorous Bayesian workflow approaches for integrating diverse data streams, which might help mitigate these domain-specific challenges, even as these methods become increasingly formalised and widely used in other domains. This paper presents a methodological framework for integrating multiple data sources in infectious disease modelling that serves both as guidance for practitioners and as a checklist for readers evaluating modelling papers, building on non-domain-specific Bayesian workflow advice. We first outline an approach for characterising epidemiological data source properties through a structured checklist, then present an iterative workflow that extends established Bayesian model development approaches to the infectious disease domain, with the checklist informing decisions throughout each workflow stage. Our workflow includes defining the research question, development of directed acyclic graph (DAG) representations of process and observation models, integration method selection, with explicit consideration of data conflicts and uncertainty quantification, inference and computation choices, and real-world considerations. Throughout, we identify feedback loops where later decisions impact earlier choices. We provide an overview of approaches for each step as well as practical guidelines for integration choices, validation strategies, and conflict resolution between data sources. In addition to outlining this workflow, we also provide guidance on using it in evolving settings, such as outbreaks, and on good reporting practices. To demonstrate this workflow, we use schematic case studies of estimating transmission intensity and give examples of how practitioners can navigate real-world trade-offs between model complexity, computational feasibility, and inferential goals. The case studies show how different data types, including individual-level observations, can provide complementary information but may also impact other workflow choices. Our suggested framework emphasises parsimony, interpretability, and model criticism. By establishing systematic workflow practices that bridge methodological rigour and practical implementation, this framework offers a foundation for improving both the quality and transparency of infectious disease modelling, particularly during rapidly evolving outbreaks where flexible, principled approaches are essential. 
 \end{abstract}
 \newpage
 
@@ -93,7 +93,7 @@ Existing guidance for practitioners is fragmented across methodological literatu
 This paper provides a framework for integrating multiple data sources in infectious disease modelling that serves both as guidance for practitioners and as a checklist for readers evaluating modelling papers, with practical implementation as the primary focus. 
 Our approach builds on established Bayesian workflows \citep{gelman2020bayesian}, encouraging iterative model building with principled uncertainty quantification. We advocate for Bayesian thinking throughout the model development process, including model specification, model criticism, and predictive checks, regardless of whether the final implementation uses Bayesian fitting methods. 
 We first outline an approach for characterising epidemiological data source properties through a structured checklist, then present an iterative workflow that extends established Bayesian model development approaches to the infectious disease domain, with the checklist informing decisions throughout each workflow stage. 
-Our workflow includes defining the research question, development of directed acyclic graph (DAG) representations of process and observation models, integration method selection, with explicit consideration of data conflicts and uncertainty quantification, model fitting choices, and real-world considerations. Throughout, we identify feedback loops where later decisions impact earlier choices. 
+Our workflow includes defining the research question, development of directed acyclic graph (DAG) representations of process and observation models, integration method selection, with explicit consideration of data conflicts and uncertainty quantification, inference and computation choices, and real-world considerations. Throughout, we identify feedback loops where later decisions impact earlier choices. 
 We provide an overview of approaches for each step as well as practical guidelines for integration choices, validation strategies, and conflict resolution between data sources. 
 As well as outlining this workflow, we also provide guidance for using it in evolving settings such as outbreaks and on good reporting practices.
 Finally, we use four case studies centred on reproduction number estimation to demonstrate this workflow, progressing in complexity from a single-source baseline, through integrating similar data sources, to more complex examples with data of different kinds and scales. 
@@ -134,6 +134,7 @@ We propose that these six characteristics be used as a checklist to guide the sy
 
 We recommend following a structured, iterative workflow for multi-data source modelling (Figure~\ref{fig:workflow}). Our suggested workflow extends established Bayesian workflow principles \citep{gelman2020bayesian} for  the specific challenges of multi-source infectious disease modelling.
 We advocate this approach because it makes modelling choices transparent, assumptions explicit, and provides principled tools for assessing model adequacy regardless of whether final inference is Bayesian or frequentist.
+The workflow should be implemented through multiple iterations, starting with high-level considerations and becoming more detailed with each pass, as some steps require later workflow components (e.g., posterior prediction requires inference and computation choices).
 
 Begin with \textbf{decision making}: clearly define your research question and target estimands (e.g., time-varying reproduction number, overdispersion parameters).
 Next, we suggest using \textbf{directed acyclic graphs (DAG)} approach to define your models. However, we depart from standard approaches in that we suggest decoupling the definition of the \textbf{process} and \textbf{observation} models.
@@ -149,7 +150,7 @@ You then face the key decisions \textbf{data integration choices}: \textbf{``Wha
 
 If combining multiple sources is not beneficial or feasible, you can proceed to single-source modelling and potentially the combination of estimates, e.g. where multiple models estimate the effective reproduction number from different data sources, and so these estimates can be ensembled.
 If integration is warranted, select among \textbf{data integration} methods. 
-Once your data sources have been integrated, it is time to make \textbf{fitting choices} , i.e. selecting an inference method based on the model structure, integration approach, and theoretical and practical considerations. 
+Once your data sources have been integrated, it is time to make \textbf{inference and computation choices}, i.e. selecting an inference method based on the model structure, integration approach, and theoretical and practical considerations. 
 Finally, \textbf{fit your model} and evaluate its performance through posterior predictive validation and sensitivity analysis.
 
 Throughout this workflow, there is the potential for feedback loops between steps so that model development is rarely a single forward pass (see Figure~\ref{fig:workflow}). 
@@ -164,7 +165,7 @@ Practitioners should expect to repeat this workflow as outbreaks evolve.
 Understanding of pathogen characteristics improves over time, research questions shift from immediate response to longer-term planning, and decision-making timescales change from days to months.
 New data sources emerge whilst surveillance systems adapt to changing circumstances.
 This evolution favours modular approaches that enable component reuse rather than bespoke models requiring complete redevelopment when applications change.
-Critical to this workflow is transparent reporting of all decisions and validation procedures, enabling both reproduction and adaptation of models for future applications.
+Critical to this workflow is transparent reporting of all decisions and validation procedures, including documentation of iterative workflow passes and decision rationales, enabling both reproduction and adaptation of models for future applications.
 
 In the following sections, we will discuss each of these steps in more detail and provide resources for further learning. We will also demonstrate this workflow in our case studies.
 
@@ -345,65 +346,141 @@ Diagnostic tools to detect conflicts in evidence synthesis models include prior-
     \label{fig:integration}
 \end{figure}
 
-\subsection{Fitting Choices}\label{sec:fitting}
+\subsection{Inference and Computation Choices}\label{sec:fitting}
 % Lead: Xiahui and Dhorasso with support from Anne Presanis
 
 Inference for infectious disease models typically involves estimating a set of parameters $\theta$ from observed data $Y$, which may include case counts, hospitalisations, deaths, wastewater surveillance or other epidemiological measurements. These data are assumed to arise from a probabilistic model characterised by a likelihood function $p(Y | \theta)$ that links the parameters to the data through both an underlying transmission dynamics (represented by the process DAG (Section \ref{sec:process}) in our workflow) and a noisy observation mechanism (captured by the observation DAG (Section \ref{sec:observation})).  The choice of inferential approach depends on the tractability of the likelihood: 
-whether $ p(Y | \theta)$ is analytically or numerically computable, intractable and requiring approximation, or entirely  unavailable (necessitating likelihood-free, simulation-based methods). This section provides a brief overview of common computational strategies, with a focus on practical considerations and current best practices.
+whether $ p(Y | \theta)$ is analytically or numerically computable, intractable and requiring approximation, or entirely  unavailable (necessitating likelihood-free, simulation-based methods). 
+
+A wide range of computational strategies exists for infectious disease model inference, with numerous methods and variants available for each broad class of approach.
+We recommend structuring inference and computation decisions through four key considerations: assessing model complexity, selecting appropriate inference methods, implementing the chosen approach, and evaluating diagnostics (Figure \ref{fig:fitting}).
+In addition, inference and computation choices involve critical feedback loops within the broader workflow: computational constraints may require approximating or restructuring the process and observation DAGs developed in earlier stages, whilst computational limitations or available expertise may favour modular rather than joint integration approaches, necessitating a return to data integration decisions.
+This section provides an overview of these considerations with detailed technical discussion and practical guidance for navigating the many available options.
 
 \begin{figure}[htbp]
     \centering
     \includegraphics[width=\textwidth]{figures/subpanel_fitting choices.drawio.pdf}
-    \caption{\textbf{Fitting choices workflow for integrating multiple data sources in infectious disease modelling.} The workflow contains four interconnected components: Model Complexity Assessment (7.1) evaluates dimensionality, hierarchical structure, likelihood tractability, and computational constraints; Inference Method Selection (7.2) chooses between likelihood-free approaches and likelihood-based methods; Diagnostics (7.3) involve convergence checks, sensitivity analysis, and computational trade-offs; and Implementation Considerations (7.4) address software choices and compatibility requirements. The interconnected arrows indicate that these components inform each other iteratively, allowing researchers to optimize the balance between model complexity, computational feasibility, and inferential accuracy when integrating multiple data sources. Also, the workflow includes key feedback mechanisms: fitting constraints may require approximating or restructuring the process DAG, leading back to stage 2 Process DAG Development; alternatively, computational constraints or available expertise may favour modular over joint integration approaches, requiring a return to stage 6 Data Integration Choices. }
+    \caption{\textbf{Inference and computation choices workflow for integrating multiple data sources in infectious disease modelling.} The workflow contains four interconnected components: Model Complexity Assessment (7.1) evaluates dimensionality, hierarchical structure, likelihood tractability, and computational constraints; Inference Method Selection (7.2) chooses between likelihood-free approaches and likelihood-based methods; Diagnostics (7.3) involve convergence checks, sensitivity analysis, and computational trade-offs; and Implementation Considerations (7.4) address software choices and compatibility requirements. The interconnected arrows indicate that these components inform each other iteratively, allowing researchers to optimize the balance between model complexity, computational feasibility, and inferential accuracy when integrating multiple data sources. Also, the workflow includes key feedback mechanisms: inference and computation constraints may require approximating or restructuring the process DAG, leading back to stage 2 Process DAG Development; alternatively, computational constraints or available expertise may favour modular over joint integration approaches, requiring a return to stage 6 Data Integration Choices. }
     \label{fig:fitting}
 \end{figure}
 
 
-\subsubsection{Likelihood-based methods}
-Likelihood-based inference encompasses frequentist and Bayesian approaches. Classical frequentist methods such as maximum likelihood estimation (MLE)\citep{myung2003tutorial, baltazar2024maximum} and profile likelihood \citep{tonsing2018profile, plank2024structured} provide well-established tools for parameter estimation. However, here we focus mainly on Bayesian methods due to their flexibility in handling uncertainty and incorporating various sources of information.
+% \subsubsection{Likelihood-based methods}
+% Likelihood-based inference encompasses frequentist and Bayesian approaches. Classical frequentist methods such as maximum likelihood estimation (MLE)\citep{myung2003tutorial, baltazar2024maximum} and profile likelihood \citep{tonsing2018profile, plank2024structured} provide well-established tools for parameter estimation. However, here we focus mainly on Bayesian methods due to their flexibility in handling uncertainty and incorporating various sources of information.
 
-Bayesian inference updates prior beliefs $ p(\theta)$ in light of observed data to obtain a posterior distribution $p(\theta | Y) \propto p(Y|\theta) \,p(\theta)$. For simple models with exponential family likelihoods, conjugate priors allow closed-form posterior solutions \citep{gelman1995bayesian,  cori2013new}. However, many infectious disease models involve complexities that preclude exact inference.
+% Bayesian inference updates prior beliefs $ p(\theta)$ in light of observed data to obtain a posterior distribution $p(\theta | Y) \propto p(Y|\theta) \,p(\theta)$. For simple models with exponential family likelihoods, conjugate priors allow closed-form posterior solutions \citep{gelman1995bayesian,  cori2013new}. However, many infectious disease models involve complexities that preclude exact inference.
 
-When the likelihood can be evaluated (up to a constant) but closed-form posteriors are unavailable, sampling-based methods, especially Markov Chain Monte Carlo (MCMC) remain the gold standard \citep{gilks1995markov, lekone2006statistical}. Common algorithms include Metropolis–Hastings \citep{hastings1970monte} and Gibbs sampling \citep{geman1984stochastic}. For latent variable models, data-augmented MCMC introduces auxiliary states to jointly infer parameters and hidden variables \citep{o1999bayesian}. More efficient techniques, such as Hamiltonian Monte Carlo (HMC) for differentiable likelihoods \citep{duane1987hybrid} and its adaptive variant No-U-Turn Sampler (NUTS) \citep{hoffman2014no, andrade2020evaluation}, leverage gradient information for faster convergence and automatic tuning. 
+% When the likelihood can be evaluated (up to a constant) but closed-form posteriors are unavailable, sampling-based methods, especially Markov Chain Monte Carlo (MCMC) remain the gold standard \citep{gilks1995markov, lekone2006statistical}. Common algorithms include Metropolis–Hastings \citep{hastings1970monte} and Gibbs sampling \citep{geman1984stochastic}. For latent variable models, data-augmented MCMC introduces auxiliary states to jointly infer parameters and hidden variables \citep{o1999bayesian}. More efficient techniques, such as Hamiltonian Monte Carlo (HMC) for differentiable likelihoods \citep{duane1987hybrid} and its adaptive variant No-U-Turn Sampler (NUTS) \citep{hoffman2014no, andrade2020evaluation}, leverage gradient information for faster convergence and automatic tuning. 
 
-Alternatives to MCMC include Variational Inference (VI), which approximates the posterior by optimizing a tractable surrogate distribution, offering scalability at the cost of some bias \citep{blei2017variational, chatzilena2019contemporary}. Similarly, the Integrated Nested Laplace Approximation (INLA) 
-offers a computationally efficient method for approximating posterior marginals in latent Gaussian models, without relying on sampling-based methods \citep{rue2017bayesian}.
+% Alternatives to MCMC include Variational Inference (VI), which approximates the posterior by optimizing a tractable surrogate distribution, offering scalability at the cost of some bias \citep{blei2017variational, chatzilena2019contemporary}. Similarly, the Integrated Nested Laplace Approximation (INLA) 
+% offers a computationally efficient method for approximating posterior marginals in latent Gaussian models, without relying on sampling-based methods \citep{rue2017bayesian}.
 
-In state-space models with high-dimensional latent state structures, the likelihood maybe intractable due to the need to marginalise over latent states. Sequential Monte Carlo (SMC) methods, or particle filters, approximate the posterior using weighted particles and yield unbiased likelihood estimates \citep{doucet2001introduction}. These can be embedded within MCMC to form particle MCMC (PMCMC) \citep{andrieu2010particle, endo2019introduction} , enabling joint parameter and latent state inference. Sequential Monte Carlo Squared (SMC$^2$) \citep{chopin2013smc2} extends this to fully sequential Bayesian updating as new data are accumulated.
+% In state-space models with high-dimensional latent state structures, the likelihood maybe intractable due to the need to marginalise over latent states. Sequential Monte Carlo (SMC) methods, or particle filters, approximate the posterior using weighted particles and yield unbiased likelihood estimates \citep{doucet2001introduction}. These can be embedded within MCMC to form particle MCMC (PMCMC) \citep{andrieu2010particle, endo2019introduction} , enabling joint parameter and latent state inference. Sequential Monte Carlo Squared (SMC$^2$) \citep{chopin2013smc2} extends this to fully sequential Bayesian updating as new data are accumulated.
 
-\subsubsection{Likelihood-Free Methods}
+% \subsubsection{Likelihood-Free Methods}
 
-Likelihood-based methods are powerful for parameter inference but rely on evaluating the likelihood function, which is sometimes infeasible for complex infectious disease models. Likelihood-free methods circumvent this by simulating from the model instead.
+% Likelihood-based methods are powerful for parameter inference but rely on evaluating the likelihood function, which is sometimes infeasible for complex infectious disease models. Likelihood-free methods circumvent this by simulating from the model instead.
 
-Approximate Bayesian Computation is a popular likelihood-free method that approximates the posterior distribution by accepting parameter values that generate simulated data close to the observed data under a predefined distance metric \citep{rubin1984bayesianly, tavare1997inferring, beaumont2002approximate}. While conceptually simple, the classical ABC rejection sampling is inefficient in high-dimensional settings, prompting the development of more advanced variants. 
+% Approximate Bayesian Computation is a popular likelihood-free method that approximates the posterior distribution by accepting parameter values that generate simulated data close to the observed data under a predefined distance metric \citep{rubin1984bayesianly, tavare1997inferring, beaumont2002approximate}. While conceptually simple, the classical ABC rejection sampling is inefficient in high-dimensional settings, prompting the development of more advanced variants. 
 
-ABC-MCMC combines ABC with MCMC to improve sampling efficiency, especially for peaked or correlated posteriors \citep{marjoram2003markov, wegmann2009efficient, kypraios2017tutorial}. However, its performance is sensitive to the choice of tolerance thresholds and proposal distributions.
+% ABC-MCMC combines ABC with MCMC to improve sampling efficiency, especially for peaked or correlated posteriors \citep{marjoram2003markov, wegmann2009efficient, kypraios2017tutorial}. However, its performance is sensitive to the choice of tolerance thresholds and proposal distributions.
 
-ABC-SMC further enhances efficiency by iteratively refining  tolerances and proposal distributions, adaptively focusing computational effort on high-probability regions and handling multi-modal posteriors more effectively \citep{sisson2007sequential, toni2009approximate, beaumont2009adaptive, drovandi2011likelihood}. 
+% ABC-SMC further enhances efficiency by iteratively refining  tolerances and proposal distributions, adaptively focusing computational effort on high-probability regions and handling multi-modal posteriors more effectively \citep{sisson2007sequential, toni2009approximate, beaumont2009adaptive, drovandi2011likelihood}. 
 
-When exact likelihoods are unavailable but the model can be simulated repeatedly, synthetic likelihood methods provide an alternative by approximating the likelihood via assuming Gaussian distributions for summary statistics \citep{wood2010statistical, price2018bayesian}. 
+% When exact likelihoods are unavailable but the model can be simulated repeatedly, synthetic likelihood methods provide an alternative by approximating the likelihood via assuming Gaussian distributions for summary statistics \citep{wood2010statistical, price2018bayesian}. 
 
-\subsubsection{Selecting the Right Tool}
+% \subsubsection{Selecting the Right Tool}
 
-Selecting an appropriate inference method involves balancing trade-offs between computational efficiency, statistical rigor, data availability, interpretability, and model complexity \citep{funk2020choices}. Rather than adopting a universal approach, the choice should be tailored to the specific modelling context and inferential goals. 
+% Selecting an appropriate inference method involves balancing trade-offs between computational efficiency, statistical rigor, data availability, interpretability, and model complexity \citep{funk2020choices}. Rather than adopting a universal approach, the choice should be tailored to the specific modelling context and inferential goals. 
 
-For evolving epidemics, a key consideration is the dynamic nature of epidemic processes and data streams. As transmission rates and intervention effects change over time, and new data arrive continuously, methods that support sequential data updates, such as SMC, are generally preferred for real-time epidemic tracking \citep{birrell2020efficient, storvik2023sequential}. In contrast, MCMC-based methods, while statistically robust, are typically better suited for retrospective analyses, due to their reliance on complete datasets, high computational demands for reanalysis, and computational intensity in high-dimensional parameter spaces. 
+% For evolving epidemics, a key consideration is the dynamic nature of epidemic processes and data streams. As transmission rates and intervention effects change over time, and new data arrive continuously, methods that support sequential data updates, such as SMC, are generally preferred for real-time epidemic tracking \citep{birrell2020efficient, storvik2023sequential}. In contrast, MCMC-based methods, while statistically robust, are typically better suited for retrospective analyses, due to their reliance on complete datasets, high computational demands for reanalysis, and computational intensity in high-dimensional parameter spaces. 
 
-When computational resources are constrained, for example during real-time outbreak monitoring or when analyzing large datasets, approximate methods like VI or ABC-SMC might offer scalable alternatives \citep{chatzilena2019contemporary, engebretsen2023real}. VI is highly scalable and typically much faster than MCMC, although it trades accuracy for speed and may not always be suitable where posterior uncertainty is important. Likelihood-free methods, while offering flexibility for complex models, tend to be computationally expensive because of repeated model simulation.
+% When computational resources are constrained, for example during real-time outbreak monitoring or when analyzing large datasets, approximate methods like VI or ABC-SMC might offer scalable alternatives \citep{chatzilena2019contemporary, engebretsen2023real}. VI is highly scalable and typically much faster than MCMC, although it trades accuracy for speed and may not always be suitable where posterior uncertainty is important. Likelihood-free methods, while offering flexibility for complex models, tend to be computationally expensive because of repeated model simulation.
 
-Beyond computational efficiency, statistical accuracy is influenced by algorithmic choices including priors distributions, tuning parameters, tolerance thresholds, and the number of particles or iterations. Full-likelihoods methods typically yield better estimator performance, subject to likelihood tractability and proper specification, whereas likelihood-free approaches often prioritise flexibility and scalability over precision \cite{alahmadi2020comparison}. 
+% Beyond computational efficiency, statistical accuracy is influenced by algorithmic choices including priors distributions, tuning parameters, tolerance thresholds, and the number of particles or iterations. Full-likelihoods methods typically yield better estimator performance, subject to likelihood tractability and proper specification, whereas likelihood-free approaches often prioritise flexibility and scalability over precision \cite{alahmadi2020comparison}. 
 
-Interpretability and ease of implementation also play a role. Certain methods integrate smoothly with probabilistic programming environments, while others may require further tuning and computational expertise. Ultimately, method selection should follow a systematic decision process that considers modeling goals, urgency or latency constraints, system complexity, and available computational resources. 
+% Interpretability and ease of implementation also play a role. Certain methods integrate smoothly with probabilistic programming environments, while others may require further tuning and computational expertise. Ultimately, method selection should follow a systematic decision process that considers modeling goals, urgency or latency constraints, system complexity, and available computational resources. 
 
-Regardless of the approach chosen, model checking, sensitivity analysis, and validation are essential to ensure that inferences are not only statistically valid but also scientifically meaningful and actionable.
+% Regardless of the approach chosen, model checking, sensitivity analysis, and validation are essential to ensure that inferences are not only statistically valid but also scientifically meaningful and actionable.
 
-\subsubsection{Practical Implementation}
+% NOTE: The following content on generative model validation should be relocated to model validation section:
+% - Content about using fully generative PPLs for simulation-based calibration
+% - Discussion of sampling from models without separate generators
+% [TO BE MOVED: "Using a fully generative probabilistic programming language like Turing.jl or NumPyro makes model validation such as simulation-based calibration easier, as one can easily sample from the model without writing separate model generators required when using other approaches."]
 
-A wide range of software tools is available to support the implementation of both likelihood-based and likelihood-free methods in infectious disease modeling. Bayesian inference platforms such as Stan, JAGS and NIMBLE are widely used for likelihood-based approaches, offering flexibility in model specification and efficient MCMC algorithms \citep{carpenter2017stan,abril2023pymc}. For more complex or high-dimensional models, Python based PyMC and Julia-based Turing.jl provide probabilistic programming environments with good performance \citep{abril2023pymc,ge2018turing,fjelde2025turing}. Using a fully generative probabilistic programming language like Turing.jl or NumPyro makes model validation such as simulation-based calibration easier, as one can easily sample from the model without writing separate model generators required when using other approaches. For more scalable alternatives to MCMC, INLA is implemented in the R-INLA package \citep{martins2013bayesian} and is particularly efficient for latent Gaussian models, including spatiotemporal structures commonly used in disease mapping and surveillance. VI is also available in PyMC and Turing.jl. These implementations allow rapid inference for large datasets or real-time modelling applications.  Additionally, tools such as LibBi support SMC-based inference for state-space models and can scale to high-dimensional problems using GPU and parallel computing \citep{murray2015bayesian}. For likelihood-free methods, ABC is supported in packages like EasyABC, abc, abctools \citep{jabot2013easy,csillery2012abc,nunes2015abctools}.
+\subsubsection{Model Complexity Assessment}
 
-% Add some stuff talking about performance on CPU vs GPU etc
-Parallelization is essential for large-scale epidemiological studies, where high-performance computing (HPC) resources are often required to handle complex models and extensive datasets. The parallelization potential varies across inference methods. MLE is highly parallelizable across data points, making it efficient scaling on both multi-core CPUs and GPUs for large datasets. Traditional MCMC methods have limited parallelization due to their sequential chain structure, GPU implementation remain challenging. Particle-based methods (PMCMC, SMC) benefit from particle-level parallelism and are well-suited for many-core GPU architectures, where thousands of particles can be processed simultaneously \citep{henriksen2012parallel}. However, INLA has low parallelization potential due to its dependence on sequential matrix operations that resist decomposition. VI scales well when processing small chunks of data at a time, where gradient calculations for each chunk can run in parallel \citep{hoffman2013stochastic}. Most modern VI implementations commonly use GPU acceleration, making them quite efficient for large datasets \citep{bingham2019pyro}. Likelihood-free methods like ABC excel in parallelization, as simulations are trivially parallelizable and GPU-friendly, though practitioners should account for potentially high memory requirements when scaling to many cores \citep{kulkarni2022hardware}. BSL allows parallelization with GPU acceleration to be possible for computationally intensive density estimation steps. When selecting methods for HPC environments, practitioners should carefully weight these parallelization capabilities against memory constraints, available hardware, and the specific computational demands of the epidemiological applications.
+Inference for infectious disease models typically involves estimating a set of parameters $\theta$ from observed data $Y$, which may include case counts, hospitalisations, deaths, wastewater surveillance or other epidemiological measurements.
+These data are assumed to arise from a probabilistic model characterised by a likelihood function $p(Y | \theta)$ that links the parameters to the data through both an underlying transmission dynamics (represented by the process DAG in our workflow) and a noisy observation mechanism (captured by the observation DAG).
+Bayesian inference updates prior beliefs $p(\theta)$ in light of observed data to obtain a posterior distribution $p(\theta | Y) \propto p(Y|\theta) \,p(\theta)$, providing a principled framework for uncertainty quantification even when using non-Bayesian fitting methods.
 
+Parameter dimensionality and structure represent key characteristics to assess.
+Low-dimensional problems (fewer than 10 parameters) differ fundamentally from high-dimensional parameter spaces (hundreds or thousands of parameters), with method performance varying substantially across this dimension (see "Handles high-dim. params.?" in Table \ref{tab:methods_comparison}).
+Parameter structure also matters: strongly correlated parameters, discrete parameter spaces, or mixed continuous-discrete problems each present distinct challenges.
+
+Likelihood tractability determines which broad classes of methods are feasible.
+Key questions include: Can the likelihood $p(Y | \theta)$ be written down analytically?
+If not analytical, can it be evaluated numerically with reasonable computational cost?
+Can the likelihood be differentiated with respect to parameters?
+Many infectious disease models involve complexities such as stochastic differential equations or discrete event processes that affect tractability.
+
+The presence and scale of latent states represents another structural consideration.
+Models may include unobserved infection times, individual-level disease states, or spatially varying transmission rates.
+The dimensionality of these latent structures relative to observed data affects computational feasibility.
+
+Computational budget constraints frame practical considerations.
+Real-time outbreak analysis demands different approaches than retrospective studies, with some methods supporting real-time inference whilst others require complete datasets (see "Capable of real-time inference?" in Table \ref{tab:methods_comparison}).
+Available computational resources, from laptops to high-performance clusters, set practical limits.
+
+\subsubsection{Inference Method Selection}
+
+Numerous inference methods and algorithmic variants exist within each broad class of approach, each with distinct computational characteristics and practical trade-offs.
+Selecting an appropriate method involves balancing considerations of computational efficiency, statistical rigour, data availability, interpretability, and model complexity.
+Rather than adopting a universal approach, the choice should be tailored to the specific modelling context and inferential goals.
+The following provides guidance for navigating these many options.
+
+Gradient-based Markov Chain Monte Carlo (MCMC) approaches represent our preferred methods when applicable due to their combination of efficiency, reliability, and ease of use.
+MCMC methods generate samples from the posterior distribution by constructing a Markov chain that converges to the target distribution, providing a flexible framework for Bayesian inference when analytical solutions are unavailable.
+Hamiltonian Monte Carlo (HMC) leverages gradient information for efficient MCMC exploration of differentiable likelihoods, with its adaptive variant No-U-Turn Sampler (NUTS) representing our default recommendation for models with continuous parameters \citep{duane1987hybrid, hoffman2014no, andrade2020evaluation}.
+These methods provide excellent diagnostics and automatic tuning, reducing the expertise barrier for reliable implementation.
+When implementing gradient-based methods, automatic differentiation backend selection matters: forward-mode differentiation suits models with few parameters (typically fewer than 10), whilst reverse-mode differentiation scales better for high-dimensional parameter spaces.
+Practitioners should test available autodiff options when possible, with systems like Turing.jl and PyMC providing backend flexibility.
+When full uncertainty quantification is less critical, Variational Inference (VI) approximates the posterior by optimising tractable surrogate distributions, offering fast approximation with modern variants like Pathfinder \citep{blei2017variational, chatzilena2019contemporary}.
+
+Sampling-based approaches become necessary when gradients are unavailable.
+Standard Markov Chain Monte Carlo (MCMC) methods including Metropolis-Hastings and Gibbs sampling handle discrete or mixed parameter spaces \citep{hastings1970monte, geman1984stochastic, gilks1995markov}.
+For discrete parameters, consider whether marginalisation is possible before resorting to sampling, as analytical integration can significantly improve efficiency and mixing.
+Parallel tempering extends these methods to multimodal posteriors by running multiple chains at different temperatures, with modern implementations available in packages like Pigeons.jl \citep{surjanovic2023pigeons}.
+These approaches require greater tuning than gradient-based methods and provide weaker diagnostics.
+
+Sequential and particle methods suit dynamic models with high-dimensional latent states.
+These approaches excel when models involve state-space formulations where latent states evolve over time and must be estimated alongside parameters.
+Sequential Monte Carlo (SMC) methods, or particle filters, approximate the posterior using weighted particles and enable state estimation in high-dimensional spaces with strong real-time capabilities \citep{doucet2001introduction}, making them particularly valuable for real-time epidemic tracking where new data arrive continuously.
+Particle MCMC (PMCMC) embeds SMC within MCMC to enable joint parameter-state inference \citep{andrieu2010particle, endo2019introduction}.
+Important limitations include particle degeneracy (when few particles carry most weight), memory scaling challenges with long time series, and complex resampling tuning.
+Table \ref{tab:methods_comparison} shows their moderate performance with high-dimensional parameters despite strength in latent state estimation.
+
+Likelihood-free approaches serve as methods of last resort due to their computational demands and limited diagnostic capabilities.
+These simulation-based methods bypass likelihood evaluation entirely, instead using model simulations to approximate the posterior distribution.
+Approximate Bayesian Computation (ABC) approximates the posterior distribution by accepting parameter values that generate simulated data close to the observed data under a predefined distance metric, whilst synthetic likelihood methods approximate the likelihood by assuming Gaussian distributions for summary statistics \citep{beaumont2002approximate, wood2010statistical, price2018bayesian}.
+Whilst these methods suffer from limited diagnostics and high computational cost, they provide essential flexibility for complex models where other approaches fail.
+
+Approximate Bayesian methods provide efficient alternatives for specific model structures.
+Integrated Nested Laplace Approximation (INLA) offers a computationally efficient method for approximating posterior marginals in latent Gaussian models, making it particularly effective for spatiotemporal disease models with spatial correlation structures \citep{rue2017bayesian}.
+This method excels when models can be reformulated with latent Gaussian components but struggles with non-Gaussian latent structures.
+Nested Laplace approximations can be integrated within other sampling schemes, allowing INLA to handle subcomponents of larger models efficiently.
+
+Deterministic approaches focus on point estimation rather than uncertainty quantification.
+Maximum Likelihood Estimation (MLE) provides point estimates for model parameters, particularly useful for simple models requiring only parameter estimates rather than full uncertainty quantification \citep{myung2003tutorial, baltazar2024maximum}.
+Profile likelihood methods extend MLE by examining the likelihood surface for individual parameters whilst optimising over others, providing confidence intervals without full posterior sampling \citep{tonsing2018profile, plank2024structured}.
+Whilst we do not generally recommend these approaches for primary analysis, they can prove useful for model validation, parameter initialisation, or exploring model behaviour when more complex methods encounter difficulties.
+
+Our recommended approach follows a decision hierarchy:
+First, attempt gradient-based MCMC (HMC/NUTS) for continuous parameter models with tractable, differentiable likelihoods.
+When discrete parameters are present, use standard MCMC with parallel tempering for multimodal posteriors.
+For state-space models with high-dimensional latent states, consider SMC/PMCMC despite their limitations.
+When models have Gaussian latent field structure, INLA may outperform sampling methods.
+Reserve likelihood-free methods for cases where likelihood evaluation proves impossible.
 
 \begin{landscape}
 \begin{table}[ht]
@@ -448,6 +525,74 @@ Best use case & Simple models & General Bayesian inference & State-space models 
 \end{tabular}
 \end{table}
 \end{landscape}
+
+Table \ref{tab:methods_comparison} provides detailed comparison across multiple criteria to support these decisions.
+
+\paragraph{Hybrid and Nested Approaches}
+
+Modern probabilistic programming languages enable sophisticated combinations of inference methods.
+INLA approximations can be nested within NUTS, using efficient spatial approximations while sampling other parameters.
+Languages like Turing.jl support mixed samplers, applying HMC to continuous parameters whilst using Gibbs for discrete components.
+SMC methods can incorporate HMC kernels for parameter moves, leveraging particle filtering for states and gradient-based sampling for parameters.
+These hybrid approaches capitalise on the strengths of multiple methods.
+
+When complex methods fail to initialise properly within prior bounds, simpler methods can provide starting values for more sophisticated approaches.
+Variational Inference often proves effective for initialisation due to its speed and robustness, whilst MLE can provide reasonable point estimates.
+However, initialisation difficulties may indicate unrealistic prior specifications, suggesting model validation should be revisited before proceeding with complex inference.
+
+\subsubsection{Practical Implementation}
+
+A wide range of software tools is available to support the implementation of both likelihood-based and likelihood-free methods in infectious disease modeling (Table \ref{tab:methods_comparison} provides specific software examples for each method). Bayesian inference platforms such as Stan, JAGS and NIMBLE are widely used for likelihood-based approaches, offering flexibility in model specification and efficient MCMC algorithms \citep{carpenter2017stan,abril2023pymc}. For more complex or high-dimensional models, Python based PyMC and Julia-based Turing.jl provide probabilistic programming environments with good performance \citep{abril2023pymc,ge2018turing,fjelde2025turing}. For more scalable alternatives to MCMC, INLA is implemented in the R-INLA package \citep{martins2013bayesian} and is particularly efficient for latent Gaussian models, including spatiotemporal structures commonly used in disease mapping and surveillance. VI is also available in PyMC and Turing.jl. These implementations allow rapid inference for large datasets or real-time modelling applications.  Additionally, tools such as LibBi support SMC-based inference for state-space models and can scale to high-dimensional problems using GPU and parallel computing \citep{murray2015bayesian}. For likelihood-free methods, ABC is supported in packages like EasyABC, abc, abctools \citep{jabot2013easy,csillery2012abc,nunes2015abctools}.
+
+The tuning burden varies substantially across inference methods, influencing both implementation time and reliability (see "Tuning required?" row in Table \ref{tab:methods_comparison}) \citep{funk2020choices}.
+HMC and NUTS require minimal manual tuning due to automatic step size adaptation and mass matrix estimation, making them accessible to practitioners with limited MCMC experience.
+Standard MCMC methods demand careful tuning of proposal distributions, step sizes, and mixing parameters, often requiring extensive pilot runs and convergence diagnostics.
+Particle methods introduce additional complexity through particle count selection, resampling thresholds, and proposal kernel tuning.
+ABC approaches require the most extensive tuning, involving summary statistic selection, distance metric choice, and tolerance threshold optimisation, often necessitating substantial methodological expertise.
+INLA and VI require less runtime tuning but may need model reformulation to fit within their respective frameworks.
+
+Parallelisation becomes essential for large-scale epidemiological studies, where high-performance computing resources are often required to handle complex models and extensive datasets.
+MCMC methods (including HMC, NUTS, Metropolis-Hastings, and Gibbs sampling) face inherent parallelisation challenges due to their sequential chain structure, though multi-chain parallelisation provides the primary scaling mechanism and parallel tempering naturally exploits multi-core architectures through temperature-parallel chains \citep{surjanovic2023pigeons}; some implementations support within-chain parallelisation for specific operations (Stan and Turing.jl for gradient calculations, GPU acceleration for matrix operations), though memory access patterns and conditional branching make GPU implementations challenging.
+VI scales exceptionally well through mini-batch parallelisation and routinely uses GPU acceleration for large datasets \citep{hoffman2013stochastic, bingham2019pyro}.
+Sequential and particle methods excel at parallelisation through particle-level parallelism across CPU cores or GPU threads, with modern GPU architectures enabling thousands of particles to process simultaneously, though memory requirements scale with particle count \citep{henriksen2012parallel}.
+Approximate methods show mixed potential: INLA has limited opportunities due to sequential matrix operations, though some implementations exploit parallel linear algebra libraries and nested approximations can parallelise across spatial or temporal components when model structure permits.
+Likelihood-free methods provide excellent opportunities as ABC simulations parallelise trivially across CPU clusters and GPU architectures, though memory requirements can become substantial for large simulated datasets \citep{kulkarni2022hardware}, whilst synthetic likelihood approaches enable GPU acceleration for density estimation.
+Deterministic approaches parallelise most effectively, with MLE highly parallelisable across data points on both multi-core CPUs and GPUs, and profile likelihood calculations naturally parallelising across parameter values.
+When selecting methods for high-performance computing environments, practitioners should weigh these parallelisation capabilities (detailed in Table \ref{tab:methods_comparison}) against memory constraints, available hardware, and computational demands specific to their epidemiological applications.
+
+
+\subsubsection{Diagnostics}
+
+The quality and availability of diagnostic tools varies substantially across inference methods, representing a key factor in method selection.
+Methods with better diagnostics are easier to use reliably, particularly for practitioners without extensive computational expertise.
+
+HMC and NUTS provide the gold standard for diagnostic information.
+Divergences indicate when the sampler fails to explore the posterior accurately, whilst the Bayesian Fraction of Missing Information (BFMI) diagnoses inefficient exploration of the typical set.
+Traditional MCMC diagnostics including $\hat{R}$ and effective sample size (ESS) complement these HMC-specific metrics.
+Energy plots and treedepth warnings provide additional insight into sampler performance.
+
+Standard MCMC methods rely on traditional diagnostics including trace plots and $\hat{R}$ statistics.
+Whilst useful, these provide less reliable indications of convergence than HMC diagnostics.
+Visual inspection of trace plots remains important but can miss subtle convergence failures.
+
+Parallel tempering adds temperature swap acceptance rates as key diagnostics.
+Poor mixing between temperatures indicates inadequate exploration of multimodal posteriors.
+Standard MCMC diagnostics apply to each temperature chain.
+
+SMC and PMCMC methods use effective sample size of particles as the primary diagnostic.
+Particle weight degeneracy indicates when resampling becomes necessary.
+Sequential diagnostics track particle diversity over time, crucial for long time series.
+
+Variational Inference provides limited diagnostic information through ELBO convergence monitoring.
+However, ELBO convergence does not guarantee accurate posterior approximation.
+Posterior predictive checks become essential for validation given limited intrinsic diagnostics.
+
+ABC methods offer minimal diagnostic capabilities.
+Acceptance rates and summary statistic distributions provide limited insight into approximation quality.
+Heavy reliance on posterior predictive checks and external validation becomes necessary.
+
+INLA provides model-specific diagnostic checks including residual analysis for latent Gaussian models.
+Marginal likelihood approximations enable model comparison but do not diagnose convergence issues.
 
 \subsection{Outbreak Evolution and Workflow Iteration}
 % Lead Sam Abbott
@@ -667,7 +812,7 @@ The following case studies will demonstrate referring back to these and blah bla
 
 
 The research question for this case study (and case studies 1 and 2) is: what is the time-varying reproduction number $R_t$ during this outbreak period?
-The objective of this case study is to showcase the workflow and explore some of the assumptions and modelling and fitting choices underlying estimation of $R_t$ from a single time series of case incidence.
+The objective of this case study is to showcase the workflow and explore some of the assumptions, modelling, and inference and computation choices underlying estimation of $R_t$ from a single time series of case incidence.
 
 
 
@@ -894,7 +1039,7 @@ We establish the baseline approach using case data to estimate $R_t$ whilst high
 Adding death data eliminates some reporting assumptions but shifts dependence to infection-to-death delay assumptions and requires new integration choices.
 Wastewater data provides population-level signals independent of testing biases but requires understanding viral shedding processes and likelihood-free fitting methods.
 Individual-level contact tracing enables direct overdispersion estimation but leads to hierarchical process models and latent variable approaches which can be computationally challenging.
-Each case study also leads to new fitting choices and model validation strategies.
+Each case study also leads to new inference and computation choices and model validation strategies.
 Throughout we highlight that considering each submodel in isolation is a useful starting point for model development and validation.
 Each case study illustrates real-world trade-offs between model complexity, computational feasibility, and parameter identifiability.
 


### PR DESCRIPTION
Major improvements:
- Rename "Fitting Choices" to "Inference and Computation Choices" throughout document
- Add comprehensive method definitions (MCMC, HMC/NUTS, VI, SMC, PMCMC, ABC, INLA, MLE)
- Restructure section hierarchy: Model Complexity Assessment and Inference Method Selection now proper subsections
- Add iterative workflow guidance emphasizing multiple passes starting high-level
- Enhance parallelisation discussion with within-chain multithreading and GPU considerations
- Add profile likelihood methods with appropriate caveats about primary use
- Include initialisation strategies using simpler methods for complex approaches
- Add nested Laplace approximation details and marginalisation advice for discrete parameters
- Integrate methods comparison table strategically throughout practical implementation
- Add autodiff backend selection guidance (forward vs reverse mode)
- Include pigeons.jl reference for parallel tempering
- Add critical feedback loops between inference choices and earlier workflow stages
- Comment out old section content for reference while preserving new structure
- Enhanced method explanations ensure all abbreviations defined on first use

🤖 Generated with [Claude Code](https://claude.ai/code)